### PR TITLE
List all projects

### DIFF
--- a/pkg/teamcity/project.go
+++ b/pkg/teamcity/project.go
@@ -191,3 +191,23 @@ func (s *ProjectService) updateProject(project *Project, isCreate bool) (*Projec
 
 	return out, nil
 }
+
+// Projects represents a collection of *Project
+type Projects struct {
+	// count
+	Count int32 `json:"count,omitempty" xml:"count"`
+
+	// project
+	Items []*Project `json:"project"`
+}
+
+// Get Retrieves all projects
+func (s *ProjectService) Get() (*Projects, error) {
+	var out Projects
+	err := s.restHelper.get("", &out, "project")
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, err
+}

--- a/pkg/teamcity/project_test.go
+++ b/pkg/teamcity/project_test.go
@@ -186,6 +186,33 @@ func TestProject_ValidateName(t *testing.T) {
 	require.Errorf(t, err, "name is required")
 }
 
+func TestProject_Get(t *testing.T) {
+	project1, _ := teamcity.NewProject(testProjectId, "Project1", "")
+	project2, _ := teamcity.NewProject("Project2", "Project2", testProjectId)
+
+	client := setup()
+	c := client.Projects
+	assert := assert.New(t)
+
+	parent, err := c.Create(project1)
+	require.NoError(t, err)
+	child, err := c.Create(project2)
+	require.NoError(t, err)
+
+	actual, _ := c.Get()
+
+	cleanUpProject(t, client, parent.ID)
+	assert.Equal(int32(7), actual.Count)
+
+	projects := make(map[string]string, 7)
+	for _, i := range actual.Items {
+		projects[i.ID] = i.Name
+	}
+
+	assert.Contains(projects, parent.ID)
+	assert.Contains(projects, child.ID)
+}
+
 func TestProject_GetUnauthorizedHandled(t *testing.T) {
 	client, _ := teamcity.New("admin", "error", http.DefaultClient)
 	_, err := client.Projects.Create(getTestProjectData(testProjectId, ""))


### PR DESCRIPTION
Implements the `Get` function on the Projects struct to list all existing projects.

Signed-off-by: Javier Moro Sotelo <javier.moro@scout24.com>