### PR TITLE
Add octopus.push.package step support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,13 @@ ci: test ## Run all the CI targets
 .PHONY: test
 test: ## Run the unit tests
 	@test -d  $(TEAMCITY_DATA_DIR) || tar xfz $(INTEGRATION_TEST_DIR)/teamcity_data.tar.gz -C $(INTEGRATION_TEST_DIR)
+	@curl -sL https://download.octopusdeploy.com/octopus-teamcity/4.42.1/Octopus.TeamCity.zip -o $(TEAMCITY_DATA_DIR)/plugins/Octopus.TeamCity.zip
 	@test -n "$$(docker ps -q -f name=$(CONTAINER_NAME))" || docker run --rm -d \
-			--name $(CONTAINER_NAME) \
-			-v $(PWD)/$(TEAMCITY_DATA_DIR):/data/teamcity_server/datadir \
-			-v $(PWD)/$(INTEGRATION_TEST_DIR)/log_dir:/opt/teamcity/logs \
-			-p 8112:8111 \
-			jetbrains/teamcity-server:2018.1.3
+		--name $(CONTAINER_NAME) \
+		-v $(PWD)/$(TEAMCITY_DATA_DIR):/data/teamcity_server/datadir \
+		-v $(PWD)/$(INTEGRATION_TEST_DIR)/log_dir:/opt/teamcity/logs \
+		-p 8112:8111 \
+		jetbrains/teamcity-server:2018.1.3
 	@echo -n "Teamcity server is booting (this may take a while)..."
 	@until $$(curl -o /dev/null -sfI $(TEAMCITY_HOST)/login.html);do echo -n ".";sleep 5;done
 	@export TEAMCITY_ADDR=$(TEAMCITY_HOST) \
@@ -54,7 +55,7 @@ test: ## Run the unit tests
 clean: clean-code clean-docker ## Clean all resources (!DESTRUCTIVE!)
 
 .PHONY: clean-code
-clean-code: ## Remove unwanted files in this project (!DESTRUCTIVE!)
+clean-code: ## Remove unwanted files in this project (!DESTRUCTIVE!
 	@cd $(TOPDIR) && git clean -ffdx && git reset --hard
 
 .PHONY: clean-docker

--- a/teamcity/build_type_step_test.go
+++ b/teamcity/build_type_step_test.go
@@ -9,13 +9,14 @@ import (
 
 type SuiteBuildTypeSteps struct {
 	suite.Suite
-	TC                    *TestContext
-	BuildTypeContext      *BuildTypeContext
-	BuildTypeID           string
-	StepPowershell        teamcity.Step
-	StepCmdLineExecutable teamcity.Step
-	StepCmdLineScript     teamcity.Step
-	AddStep               func(teamcity.Step) teamcity.Step
+	TC                     *TestContext
+	BuildTypeContext       *BuildTypeContext
+	BuildTypeID            string
+	StepPowershell         teamcity.Step
+	StepCmdLineExecutable  teamcity.Step
+	StepCmdLineScript      teamcity.Step
+	StepOctopusPushPackage teamcity.Step
+	AddStep                func(teamcity.Step) teamcity.Step
 }
 
 func NewSuiteBuildTypeSteps(t *testing.T) *SuiteBuildTypeSteps {
@@ -25,12 +26,12 @@ func NewSuiteBuildTypeSteps(t *testing.T) *SuiteBuildTypeSteps {
 func (suite *SuiteBuildTypeSteps) SetupSuite() {
 	suite.StepPowershell, _ = teamcity.NewStepPowershellScriptFile("step1", "build.ps1", "")
 	suite.StepCmdLineExecutable, _ = teamcity.NewStepCommandLineExecutable("step_exe", "./script.sh", "hello")
-	suite.StepCmdLineScript, _ = teamcity.NewStepCommandLineExecutable("step_exe", "./script.sh", "hello")
 	script := `echo "Hello World
 	echo "World, Hello!
 	export HELLO_WORLD=1
 	`
 	suite.StepCmdLineScript, _ = teamcity.NewStepCommandLineScript("step_exe", script)
+	suite.StepOctopusPushPackage, _ = teamcity.NewStepOctopusPushPackage("Octopus package")
 }
 
 func (suite *SuiteBuildTypeSteps) SetupTest() {
@@ -58,6 +59,10 @@ func (suite *SuiteBuildTypeSteps) TestAdd_StepCmdLineExecutable() {
 
 func (suite *SuiteBuildTypeSteps) TestAdd_StepCmdLineScript() {
 	suite.AddStep(suite.StepCmdLineScript)
+}
+
+func (suite *SuiteBuildTypeSteps) TestAdd_StepOctopusPushPackage() {
+	suite.AddStep(suite.StepOctopusPushPackage)
 }
 
 func (suite *SuiteBuildTypeSteps) GetSteps(buildTypeID string) []teamcity.Step {

--- a/teamcity/step.go
+++ b/teamcity/step.go
@@ -14,7 +14,8 @@ const (
 	//StepTypeDotnetCli step type
 	StepTypeDotnetCli BuildStepType = "dotnet.cli"
 	//StepTypeCommandLine (shell/cmd) step type
-	StepTypeCommandLine BuildStepType = "simpleRunner"
+	StepTypeCommandLine        BuildStepType = "simpleRunner"
+	StepTypeOctopusPushPackage BuildStepType = "octopus.push.package"
 )
 
 //StepExecuteMode represents how a build configuration step will execute regarding others.
@@ -96,6 +97,12 @@ var stepReadingFunc = func(dt []byte, out interface{}) error {
 			return err
 		}
 		step = &cmd
+	case string(StepTypeOctopusPushPackage):
+		var opp StepOctopusPushPackage
+		if err := opp.UnmarshalJSON(dt); err != nil {
+			return err
+		}
+		step = &opp
 	default:
 		return fmt.Errorf("Unsupported step type: '%s' (id:'%s')", payload.Type, payload.ID)
 	}

--- a/teamcity/step_command_line.go
+++ b/teamcity/step_command_line.go
@@ -64,7 +64,7 @@ func (s *StepCommandLine) GetName() string {
 	return s.Name
 }
 
-//Type returns the step type, in this case "StepTypePowershell".
+//Type returns the step type, in this case "StepTypeCommandLine".
 func (s *StepCommandLine) Type() BuildStepType {
 	return StepTypeCommandLine
 }

--- a/teamcity/step_octopus_push_package.go
+++ b/teamcity/step_octopus_push_package.go
@@ -64,14 +64,18 @@ func (s *StepOctopusPushPackage) properties() *Properties {
 	return props
 }
 
-func (s *StepOctopusPushPackage) MarshalJSON() ([]byte, error) {
-	out := &stepJSON{
+func (s *StepOctopusPushPackage) serializable() *stepJSON {
+	return &stepJSON{
 		ID:         s.ID,
 		Name:       s.Name,
 		Type:       s.stepType,
 		Properties: s.properties(),
 	}
+}
 
+//MarshalJSON implements JSON serialization for StepOctopusPushPackage
+func (s *StepOctopusPushPackage) MarshalJSON() ([]byte, error) {
+	out := s.serializable()
 	return json.Marshal(out)
 }
 

--- a/teamcity/step_octopus_push_package.go
+++ b/teamcity/step_octopus_push_package.go
@@ -1,0 +1,121 @@
+package teamcity
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// StepOctopusPushPackage represents a a build step of type "octopus.push.package"
+type StepOctopusPushPackage struct {
+	ID       string
+	Name     string
+	stepType string
+	stepJSON *stepJSON
+
+	// Specify Octopus web portal URL.
+	Host string
+
+	// Specify Octopus API key.
+	ApiKey string
+
+	// Specify  Package path patterns.
+	PackagePaths string
+
+	// Force overwrite existing packages.
+	ForcePush bool
+
+	// Automatically publish any packages as TeamCity build artifacts.
+	PublishArtifacts bool
+
+	// Additional arguments to be passed to Octo.exe.
+	AdditionalCommandLineArguments string
+}
+
+func NewStepOctopusPushPackage(name string) (*StepOctopusPushPackage, error) {
+	return &StepOctopusPushPackage{
+		Name:     name,
+		stepType: StepTypeOctopusPushPackage,
+	}, nil
+}
+
+func (s *StepOctopusPushPackage) GetID() string {
+	return s.ID
+}
+
+func (s *StepOctopusPushPackage) GetName() string {
+	return s.Name
+}
+
+func (s *StepOctopusPushPackage) Type() BuildStepType {
+	return StepTypeOctopusPushPackage
+}
+
+func (s *StepOctopusPushPackage) properties() *Properties {
+	props := NewPropertiesEmpty()
+	props.AddOrReplaceValue("teamcity.step.mode", "default")
+	props.AddOrReplaceValue("octopus_host", s.Host)
+	props.AddOrReplaceValue("secure:octopus_apikey", s.ApiKey)
+	props.AddOrReplaceValue("octopus_packagepaths", s.PackagePaths)
+	props.AddOrReplaceValue("octopus_forcepush", strconv.FormatBool(s.ForcePush))
+	props.AddOrReplaceValue("octopus_publishartifacts", strconv.FormatBool(s.PublishArtifacts))
+	props.AddOrReplaceValue("octopus_additionalcommandlinearguments", s.AdditionalCommandLineArguments)
+
+	return props
+}
+
+func (s *StepOctopusPushPackage) MarshalJSON() ([]byte, error) {
+	out := &stepJSON{
+		ID:         s.ID,
+		Name:       s.Name,
+		Type:       s.stepType,
+		Properties: s.properties(),
+	}
+
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON implements JSON deserialization for StepOctopusPushPackage
+func (s *StepOctopusPushPackage) UnmarshalJSON(data []byte) error {
+	var aux stepJSON
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if aux.Type != string(StepTypeOctopusPushPackage) {
+		return fmt.Errorf("invalid type %s trying to deserialize into StepOctopusPushPackage entity", aux.Type)
+	}
+	s.Name = aux.Name
+	s.ID = aux.ID
+	s.stepType = StepTypeOctopusPushPackage
+
+	props := aux.Properties
+	if v, ok := props.GetOk("octopus_host"); ok {
+		s.Host = v
+	}
+
+	if v, ok := props.GetOk("secure:octopus_apikey"); ok {
+		s.ApiKey = v
+	}
+
+	if v, ok := props.GetOk("octopus_packagepaths"); ok {
+		s.PackagePaths = v
+	}
+
+	if v, ok := props.GetOk("octopus_forcepush"); ok {
+		converted_value, _ := strconv.ParseBool(v)
+		s.ForcePush = converted_value
+	}
+
+	if v, ok := props.GetOk("octopus_publishartifacts"); ok {
+		converted_value, _ := strconv.ParseBool(v)
+		s.PublishArtifacts = converted_value
+	}
+
+	if v, ok := props.GetOk("octopus_additionalcommandlinearguments"); ok {
+		s.AdditionalCommandLineArguments = v
+	}
+
+	return nil
+
+}


### PR DESCRIPTION
This patch implements the support for Octopus
(https://octopus.com/docs/api-and-integration/teamcity). It allows to
define a new type of build step: "octopus.push.package".